### PR TITLE
feat(deployment): Set siteMetadata URL to dynamic URL based on environment.

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -34,8 +34,8 @@ export async function generateMetadata({
       url: new URL(siteURL),
       images: [
         {
-          url: `${siteURL}/opengraph-image`,
-          secureUrl: `${siteURL}/opengraph-image`,
+          url: '/opengraph-image.png',
+          secureUrl: '/opengraph-image.png',
           type: 'image/png',
           alt: `A Blog about ${post.summary} by ${post.author}`,
           width: 1200,

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -34,8 +34,8 @@ export async function generateMetadata({
       url: new URL(siteURL),
       images: [
         {
-          url: '/opengraph-image.png',
-          secureUrl: '/opengraph-image.png',
+          url: new URL(`${siteURL}/opengraph-image`),
+          secureUrl: new URL(`${siteURL}/opengraph-image`),
           type: 'image/png',
           alt: `A Blog about ${post.summary} by ${post.author}`,
           width: 1200,

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -7,7 +7,7 @@ import { allBlogs } from 'contentlayer/generated';
 import { Metadata } from 'next';
 
 const siteTitle = 'Blog - ' + siteMetadata.title;
-const siteDescription = 'My Blogs - ' + siteMetadata.title;
+const siteDescription = 'Blogs - ' + siteMetadata.title;
 const siteURL = `${siteMetadata.siteUrl}/blog`;
 
 export const metadata: Metadata = {

--- a/content/siteMetadata.ts
+++ b/content/siteMetadata.ts
@@ -1,3 +1,21 @@
+let deploymentURL = 'https://localhost:3000';
+
+function getBranch(url: string) {
+  // fork-portfolio-git-prod-env-urls-jammutkarshs-projects.vercel.app
+  const startIndex = url.search('git-');
+  const endIndex = url.search('-jammutkarshs-projects.vercel.app');
+  return url.substring(startIndex + 4, endIndex);
+}
+
+if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
+  if (getBranch(process.env.VERCEL_BRANCH_URL || '') === 'utkarshchourasia-in') {
+    deploymentURL = 'https://utkarshchourasia.in';
+  } else {
+    deploymentURL =
+      `https://${process.env.NEXT_PUBLIC_VERCEL_URL}` || 'https://utkarshchourasia.in';
+  }
+}
+
 const siteMetadata = {
   title: 'Utkarsh Chourasia',
   author: 'Utkarsh Chourasia',
@@ -6,7 +24,7 @@ const siteMetadata = {
   bio: 'Server Side Engineer',
   language: 'en-us',
   theme: 'system', // system, dark or light
-  siteUrl: 'https://utkarshchourasia.in',
+  siteUrl: deploymentURL,
   siteRepo: 'https://github.com/jammutkarsh/fork-portfolio',
   siteLogo: '/static/images/logo.png',
   image: '/static/images/avatar.jpg',


### PR DESCRIPTION
The URL of open-graph images in preview was static. This made testing of open-graph and metadata in general difficult.

This PR fixes that and allows us to set the dynamic URL based on deployment environment.

- For Production: It defaults to the domain name.
- For Preview: It picks up the environment variables at build and run time from Vercel